### PR TITLE
chore: add tokens, only request on peggy address

### DIFF
--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	_ "embed"
 	"encoding/json"
+
 	"os"
 	"os/signal"
 	"strings"
@@ -13,8 +14,6 @@ import (
 	log "github.com/InjectiveLabs/suplog"
 	"github.com/ethereum/go-ethereum/common"
 )
-
-const PeggyPrefix = "peggy"
 
 //go:embed token_meta.json
 var tokenMetaFileContent []byte
@@ -84,16 +83,12 @@ func GetTokenByAddress(address string) *Token {
 	if strings.ToLower(address) == "inj" {
 		return GetTokenBySymbol("inj")
 	}
-
+	address = strings.ToLower(strings.TrimPrefix(address, "peggy"))
 	addressMapLock.RLock()
-	token, ok := addressMap[strings.ToLower(strings.TrimPrefix(address, PeggyPrefix))]
+	token, ok := addressMap[address]
 	addressMapLock.RUnlock()
 	if ok && token != nil {
 		return token
-	}
-
-	if !strings.HasPrefix(address, PeggyPrefix) {
-		return nil
 	}
 
 	// token not exist in address map, search from alchemy

--- a/pkg/token/token_meta.json
+++ b/pkg/token/token_meta.json
@@ -588,7 +588,7 @@
   "XPRT": {
     "address": "0xae837EacBAE2a6bA166ce0DEd5C72340f212835c",
     "coinGeckoId": "persistence",
-    "denom": "ibc/a0cc0cf735bfb30e730c70019d4218a1244ff383503ff7579c9201ab93ca9293",
+    "denom": "ibc/B786E7CBBF026F6F15A8DA248E0F18C62A0F7A70CB2DABD9239398C8B5150ABB",
     "metaSource": "custom",
     "meta": {
       "name": "Persistence",
@@ -634,6 +634,7 @@
     "address": "",
     "coinGeckoId": "polkadot",
     "metaSource": "custom",
+    "denom": "ibc/624BA9DD171915A2B9EA70F69638B2CEA179959850C1A586F6C485498F29EDD4",
     "meta": {
       "name": "Polkadot",
       "symbol": "DOT",
@@ -806,6 +807,18 @@
       "symbol": "SOL",
       "decimals": 8,
       "logo": "https://assets.coingecko.com/coins/images/4128/small/solana.png?1640133422"
+    }
+  },
+  "CRE": {
+    "address": "",
+    "coinGeckoId": "crescent-network",
+    "denom": "ibc/3A6DD3358D9F7ADD18CDE79BA10B400511A5DE4AE2C037D7C9639B52ADAF35C6",
+    "metaSource": "Custom",
+    "meta": {
+      "name": "Cresent Network",
+      "symbol": "CRE",
+      "decimals": 6,
+      "logo": "https://assets.coingecko.com/coins/images/25061/small/logo_200x200.png?1649943220"
     }
   }
 }

--- a/pkg/token/token_meta.json
+++ b/pkg/token/token_meta.json
@@ -747,5 +747,53 @@
       "decimals": 6,
       "logo": "https://static.alchemyapi.io/images/assets/825.png"
     }
+  },
+  "axlUSDC": {
+    "address": "",
+    "coinGeckoId": "usd-coin",
+    "denom": "ibc/7E1AF94AD246BE522892751046F0C959B768642E5671CC3742264068D49553C0",
+    "metaSource": "Custom",
+    "meta": {
+      "name": "Axelar Wrapped USDC",
+      "symbol": "USDC",
+      "decimals": 6,
+      "logo": "https://assets.coingecko.com/coins/images/26476/small/axlUSDC.png?1658207579"
+    }
+  },
+  "ETHBTCTrend": {
+    "address": "",
+    "coinGeckoId": "",
+    "denom": "peggy0x6b7f87279982d919Bbf85182DDeAB179B366D8f2",
+    "metaSource": "Custom",
+    "meta": {
+      "name": "ETH-BTC Trend",
+      "symbol": "ETHBTCTrend",
+      "decimals": 18,
+      "logo": "https://assets.coingecko.com/coins/images/26476/small/axlUSDC.png?1658207579"
+    }
+  },
+  "USDCet": {
+    "address": "",
+    "coinGeckoId": "usd-coin",
+    "denom": "factory/inj14ejqjyq8um4p3xfqj74yld5waqljf88f9eneuk/inj1q6zlut7gtkzknkk773jecujwsdkgq882akqksk",
+    "metaSource": "Custom",
+    "meta": {
+      "name": "Wormhole Wrapped USDC",
+      "symbol": "USDC",
+      "decimals": 6,
+      "logo": "https://static.alchemyapi.io/images/assets/3408.png"
+    }
+  },
+  "USDCso": {
+    "address": "",
+    "coinGeckoId": "usd-coin",
+    "denom": "factory/inj14ejqjyq8um4p3xfqj74yld5waqljf88f9eneuk/inj12pwnhtv7yat2s30xuf4gdk9qm85v4j3e60dgvu",
+    "metaSource": "Custom",
+    "meta": {
+      "name": "Wormhole Wrapped USDC",
+      "symbol": "USDC",
+      "decimals": 6,
+      "logo": "https://static.alchemyapi.io/images/assets/3408.png"
+    }
   }
 }

--- a/pkg/token/token_meta.json
+++ b/pkg/token/token_meta.json
@@ -795,5 +795,17 @@
       "decimals": 6,
       "logo": "https://static.alchemyapi.io/images/assets/3408.png"
     }
+  },
+  "SOL": {
+    "address": "",
+    "coinGeckoId": "solana",
+    "denom": "factory/inj14ejqjyq8um4p3xfqj74yld5waqljf88f9eneuk/inj1sthrn5ep8ls5vzz8f9gp89khhmedahhdkqa8z3",
+    "metaSource": "Custom",
+    "meta": {
+      "name": "Wormhole Wrapped SOL",
+      "symbol": "SOL",
+      "decimals": 8,
+      "logo": "https://assets.coingecko.com/coins/images/4128/small/solana.png?1640133422"
+    }
   }
 }

--- a/pkg/token/token_meta.json
+++ b/pkg/token/token_meta.json
@@ -779,7 +779,7 @@
     "denom": "factory/inj14ejqjyq8um4p3xfqj74yld5waqljf88f9eneuk/inj1q6zlut7gtkzknkk773jecujwsdkgq882akqksk",
     "metaSource": "Custom",
     "meta": {
-      "name": "Wormhole Wrapped USDC",
+      "name": "USC Coin (Wormhole from Ethereum)",
       "symbol": "USDC",
       "decimals": 6,
       "logo": "https://static.alchemyapi.io/images/assets/3408.png"
@@ -791,7 +791,7 @@
     "denom": "factory/inj14ejqjyq8um4p3xfqj74yld5waqljf88f9eneuk/inj12pwnhtv7yat2s30xuf4gdk9qm85v4j3e60dgvu",
     "metaSource": "Custom",
     "meta": {
-      "name": "Wormhole Wrapped USDC",
+      "name": "USD Coin (Wormhole from Solana)",
       "symbol": "USDC",
       "decimals": 6,
       "logo": "https://static.alchemyapi.io/images/assets/3408.png"


### PR DESCRIPTION
# Changes
- Add mainnet token metadata 

- We should think of a proper way to update token metadata like in this case, since we can't create a new indexer version / patch commit only for token and marking listing doesn't wait for release