### PR TITLE
fix/ldo market base and quote

### DIFF
--- a/pkg/curatedLists/hummingbot/markets.json
+++ b/pkg/curatedLists/hummingbot/markets.json
@@ -665,7 +665,7 @@
             "makerFeeRate": "-0.0001",
             "takerFeeRate": "0.001",
             "serviceProviderFee": "0.4",
-            "minPriceTickSize": "0.0000000000000001",
+            "minPriceTickSize": "0.000000000000001",
             "minQuantityTickSize": "1000000000000000"
         },
         {
@@ -954,7 +954,7 @@
             "makerFeeRate": "-0.0001",
             "takerFeeRate": "0.001",
             "serviceProviderFee": "0.4",
-            "minPriceTickSize": "0.0001",
+            "minPriceTickSize": "0.001",
             "minQuantityTickSize": "1000"
         },
         {
@@ -1111,7 +1111,7 @@
             "takerFeeRate": "0.001",
             "serviceProviderFee": "0.4",
             "minPriceTickSize": "0.0001",
-            "minQuantityTickSize": "1000000"
+            "minQuantityTickSize": "10000000"
         },
         {
             "marketId": "0x84ba79ffde31db8273a9655eb515cb6cadfdf451b8f57b83eb3f78dca5bbbe6d",
@@ -1290,18 +1290,8 @@
         {
             "marketId": "0x7fce43f1140df2e5f16977520629e32a591939081b59e8fbc1e1c4ddfa77a044",
             "ticker": "LDO/USDC",
-            "baseDenom": "factory/inj14ejqjyq8um4p3xfqj74yld5waqljf88f9eneuk/inj1q6zlut7gtkzknkk773jecujwsdkgq882akqksk",
+            "baseDenom": "factory/inj14ejqjyq8um4p3xfqj74yld5waqljf88f9eneuk/inj1me6t602jlndzxgv2d7ekcnkjuqdp7vfh4txpyy",
             "baseTokenMeta":
-            {
-                "name": "USC Coin (Wormhole from Ethereum)",
-                "address": "0x0000000000000000000000000000000000000000",
-                "symbol": "USDC",
-                "logo": "https://static.alchemyapi.io/images/assets/3408.png",
-                "decimals": 6,
-                "updatedAt": 1681165436593
-            },
-            "quoteDenom": "factory/inj14ejqjyq8um4p3xfqj74yld5waqljf88f9eneuk/inj1me6t602jlndzxgv2d7ekcnkjuqdp7vfh4txpyy",
-            "quoteTokenMeta":
             {
                 "name": "Lido DAO",
                 "address": "0x0000000000000000000000000000000000000000",
@@ -1310,6 +1300,17 @@
                 "decimals": 8,
                 "updatedAt": 1681165436593
             },
+            "quoteDenom": "factory/inj14ejqjyq8um4p3xfqj74yld5waqljf88f9eneuk/inj1q6zlut7gtkzknkk773jecujwsdkgq882akqksk",
+            "quoteTokenMeta":
+            {
+                "name": "USC Coin (Wormhole from Ethereum)",
+                "address": "0x0000000000000000000000000000000000000000",
+                "symbol": "USDC",
+                "logo": "https://static.alchemyapi.io/images/assets/3408.png",
+                "decimals": 6,
+                "updatedAt": 1681165436593
+            },
+
             "makerFeeRate": "-0.0001",
             "takerFeeRate": "0.001",
             "serviceProviderFee": "0.4",
@@ -1582,7 +1583,7 @@
             "takerFeeRate": "0.001",
             "serviceProviderFee": "0.4",
             "isPerpetual": true,
-            "minPriceTickSize": "100",
+            "minPriceTickSize": "1000",
             "minQuantityTickSize": "0.1"
         },
         {

--- a/pkg/curatedLists/hummingbot/markets.json
+++ b/pkg/curatedLists/hummingbot/markets.json
@@ -1383,7 +1383,7 @@
             {
                 "name": "Wrapped Matic",
                 "address": "0x0000000000000000000000000000000000000000",
-                "symbol": "wMATIC",
+                "symbol": "WMATIC",
                 "logo": "https://assets.coingecko.com/coins/images/14073/large/matic.png?1628852392",
                 "decimals": 8,
                 "updatedAt": 1681165436589

--- a/pkg/curatedLists/hummingbot/markets.json
+++ b/pkg/curatedLists/hummingbot/markets.json
@@ -665,7 +665,7 @@
             "makerFeeRate": "-0.0001",
             "takerFeeRate": "0.001",
             "serviceProviderFee": "0.4",
-            "minPriceTickSize": "0.000000000000001",
+            "minPriceTickSize": "0.0000000000000001",
             "minQuantityTickSize": "1000000000000000"
         },
         {
@@ -954,7 +954,7 @@
             "makerFeeRate": "-0.0001",
             "takerFeeRate": "0.001",
             "serviceProviderFee": "0.4",
-            "minPriceTickSize": "0.001",
+            "minPriceTickSize": "0.0001",
             "minQuantityTickSize": "1000"
         },
         {
@@ -1111,7 +1111,7 @@
             "takerFeeRate": "0.001",
             "serviceProviderFee": "0.4",
             "minPriceTickSize": "0.0001",
-            "minQuantityTickSize": "10000000"
+            "minQuantityTickSize": "1000000"
         },
         {
             "marketId": "0x84ba79ffde31db8273a9655eb515cb6cadfdf451b8f57b83eb3f78dca5bbbe6d",
@@ -1286,36 +1286,6 @@
             "serviceProviderFee": "0.4",
             "minPriceTickSize": "0.0000000000000001",
             "minQuantityTickSize": "10000000000000000000"
-        },
-        {
-            "marketId": "0x7fce43f1140df2e5f16977520629e32a591939081b59e8fbc1e1c4ddfa77a044",
-            "ticker": "LDO/USDC",
-            "baseDenom": "factory/inj14ejqjyq8um4p3xfqj74yld5waqljf88f9eneuk/inj1me6t602jlndzxgv2d7ekcnkjuqdp7vfh4txpyy",
-            "baseTokenMeta":
-            {
-                "name": "Lido DAO",
-                "address": "0x0000000000000000000000000000000000000000",
-                "symbol": "LDO",
-                "logo": "https://assets.coingecko.com/coins/images/13573/large/Lido_DAO.png?1609873644",
-                "decimals": 8,
-                "updatedAt": 1681165436593
-            },
-            "quoteDenom": "factory/inj14ejqjyq8um4p3xfqj74yld5waqljf88f9eneuk/inj1q6zlut7gtkzknkk773jecujwsdkgq882akqksk",
-            "quoteTokenMeta":
-            {
-                "name": "USC Coin (Wormhole from Ethereum)",
-                "address": "0x0000000000000000000000000000000000000000",
-                "symbol": "USDC",
-                "logo": "https://static.alchemyapi.io/images/assets/3408.png",
-                "decimals": 6,
-                "updatedAt": 1681165436593
-            },
-
-            "makerFeeRate": "-0.0001",
-            "takerFeeRate": "0.001",
-            "serviceProviderFee": "0.4",
-            "minPriceTickSize": "0.1",
-            "minQuantityTickSize": "1000"
         },
         {
             "marketId": "0x66a113e1f0c57196985f8f1f1cfce2f220fa0a96bca39360c70b6788a0bc06e0",
@@ -1583,7 +1553,7 @@
             "takerFeeRate": "0.001",
             "serviceProviderFee": "0.4",
             "isPerpetual": true,
-            "minPriceTickSize": "1000",
+            "minPriceTickSize": "100",
             "minQuantityTickSize": "0.1"
         },
         {

--- a/pkg/curatedLists/hummingbot/tokens.json
+++ b/pkg/curatedLists/hummingbot/tokens.json
@@ -573,14 +573,14 @@
       "logo": "https://assets.coingecko.com/coins/images/16547/large/arbitrium.png?1624418103"
     }
   },
-  "wMATIC": {
+  "WMATIC": {
     "address": "",
     "coinGeckoId": "wmatic",
     "denom": "factory/inj14ejqjyq8um4p3xfqj74yld5waqljf88f9eneuk/inj1dxv423h8ygzgxmxnvrf33ws3k94aedfdevxd8h",
     "metaSource": "Custom",
     "meta": {
       "name": "Wrapped Matic",
-      "symbol": "wMATIC",
+      "symbol": "WMATIC",
       "decimals": 8,
       "logo": "https://assets.coingecko.com/coins/images/14073/large/matic.png?1628852392"
     }

--- a/pkg/token/token_meta.json
+++ b/pkg/token/token_meta.json
@@ -893,14 +893,14 @@
       "logo": "https://assets.coingecko.com/coins/images/24383/small/apecoin.jpg?1647476455"
     }
   },
-  "wMATIC": {
+  "WMATIC": {
     "address": "",
     "coinGeckoId": "wmatic",
     "denom": "factory/inj14ejqjyq8um4p3xfqj74yld5waqljf88f9eneuk/inj1dxv423h8ygzgxmxnvrf33ws3k94aedfdevxd8h",
     "metaSource": "Custom",
     "meta": {
       "name": "Wrapped Matic",
-      "symbol": "wMATIC",
+      "symbol": "WMATIC",
       "decimals": 8,
       "logo": "https://assets.coingecko.com/coins/images/14073/large/matic.png?1628852392"
     }


### PR DESCRIPTION
Applied changes in the curated market metadata info files to make the consistent with the INI file in the Python SDK:

The differences founds are the following:

Markets in INI file and in the new version, but with differences:

- Market LDO/USDC
    - base_decimals is 8 in INI file, 6 in the info loaded from the indexer (current branch logic).

Also changed references to `wMATIC` to be `WMATIC`.